### PR TITLE
Fix resource detection in auth filter

### DIFF
--- a/src/java/filter/AuthenFilter3.java
+++ b/src/java/filter/AuthenFilter3.java
@@ -94,8 +94,8 @@ public class AuthenFilter3 implements Filter {
             }
 
             // Lấy tên tài nguyên
-            int index = uri.lastIndexOf("/");
-            String resource = uri.substring(index + 1);
+            String[] parts = uri.split("/");
+            String resource = parts.length > 0 ? parts[parts.length - 1] : uri;
 
             HttpSession session = req.getSession(false);
             if (session == null || session.getAttribute("user") == null) {


### PR DESCRIPTION
## Summary
- fix resource name extraction logic in `AuthenFilter3`

## Testing
- `ant -noinput -buildfile build.xml` *(fails: ant not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684af7f0076483279725936a5b84df2d