### PR TITLE
Fix login redirect path

### DIFF
--- a/src/java/filter/AuthenFilter3.java
+++ b/src/java/filter/AuthenFilter3.java
@@ -99,7 +99,7 @@ public class AuthenFilter3 implements Filter {
 
             HttpSession session = req.getSession(false);
             if (session == null || session.getAttribute("user") == null) {
-                res.sendRedirect(LOGIN_PAGE);
+                res.sendRedirect(req.getContextPath() + "/" + LOGIN_PAGE);
                 return;
             }
 
@@ -116,7 +116,7 @@ public class AuthenFilter3 implements Filter {
             }
         } catch (Exception e) {
             e.printStackTrace();  // Nên dùng logger thực tế
-            ((HttpServletResponse) response).sendRedirect(LOGIN_PAGE);
+            ((HttpServletResponse) response).sendRedirect(((HttpServletRequest)request).getContextPath() + "/" + LOGIN_PAGE);
         }
     }
 


### PR DESCRIPTION
## Summary
- update AuthenFilter3 to redirect to login through the context path

## Testing
- `javac -version`
- `ant -p` *(fails: command not found)*
- `javac -cp "$(ls -d /usr/local/openjdk-*/lib | head -n 1)/../lib/javax.servlet-api.jar" src/java/filter/AuthenFilter3.java` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_684afd298f788327876fc99c1eeba447