### PR TITLE
Handle checkout without productId

### DIFF
--- a/src/java/controller/CartServlet.java
+++ b/src/java/controller/CartServlet.java
@@ -49,7 +49,11 @@ public class CartServlet extends HttpServlet {
         }
 
         String action = request.getParameter("action");
-        int productId = Integer.parseInt(request.getParameter("productId"));
+        int productId = 0;
+        String productIdParam = request.getParameter("productId");
+        if (productIdParam != null && !productIdParam.isEmpty()) {
+            productId = Integer.parseInt(productIdParam);
+        }
 
         switch (action) {
             case "add":


### PR DESCRIPTION
## Summary
- avoid parsing `productId` when it is not supplied

This fixes a NumberFormatException when submitting the checkout form.

## Testing
- `ant -p` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685167dfb8348327b47a5427976f2975